### PR TITLE
feat: grimdark interface with animated resolution

### DIFF
--- a/app.js
+++ b/app.js
@@ -610,7 +610,7 @@ function afficherPhase() {
   choixMelanges.forEach((c) => {
     const btn = document.createElement("div");
     btn.className = "choice";
-    btn.innerHTML = `<div class="c-title">${c.texte}</div><div class="c-tag">${c.tag}</div>`;
+    btn.innerHTML = `<div class="c-title">${c.texte}</div>`;
     btn.addEventListener("click", () => choisir(c));
     choicesEl.appendChild(btn);
   });
@@ -627,7 +627,7 @@ function choisir(choix) {
   updateHUD();
 
   const line = document.createElement("div");
-  line.innerHTML = `Tour <b>${p.tour}</b> — <i>${p.phase}</i> : ${choix.texte} <span class="meta">(${choix.tag})</span>`;
+  line.innerHTML = `Tour <b>${p.tour}</b> — <i>${p.phase}</i> : ${choix.texte}`;
   logEl.appendChild(line);
   logEl.scrollTop = logEl.scrollHeight;
 
@@ -636,10 +636,12 @@ function choisir(choix) {
   if (choix.effet.menace) eff.push(`Menace ${choix.effet.menace > 0 ? "+" : ""}${choix.effet.menace}`);
   if (choix.effet.tyr)    eff.push(`Arrivées Tyranides ${choix.effet.tyr > 0 ? "+" : ""}${choix.effet.tyr}`);
   const effStr = eff.length ? `Effets appliqués : ${eff.join(" | ")}` : "Aucun effet numérique.";
-  modalText.innerHTML = `<p>${choix.fluff}</p><p><em>${choix.bonus}</em></p><p class="meta">${effStr}</p>`;
-  modalMeta.textContent = `Tag : ${choix.tag} — Totaux → Menace ${menace} | Arrivées ${tyr}`;
-  lastTagEl.textContent = choix.tag;
+  modalText.innerHTML = `<p id="fluff" class="wow">${choix.fluff}</p><p id="bonus" class="wow hidden"><em>${choix.bonus}</em></p><p id="eff" class="meta wow hidden">${effStr}</p>`;
+  modalMeta.textContent = `Totaux → Menace ${menace} | Arrivées ${tyr}`;
+  lastTagEl.textContent = eff.length ? eff.join(" | ") : "—";
   showModal(true);
+  setTimeout(() => document.getElementById("bonus").classList.remove("hidden"), 1000);
+  setTimeout(() => document.getElementById("eff").classList.remove("hidden"), 2000);
 
   nextBtn.disabled = false;
 }

--- a/styles.css
+++ b/styles.css
@@ -6,9 +6,9 @@
 }
 
 body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: #0b0b0f;
-  color: #eee;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  background: radial-gradient(circle at top, #0b0b0f 0%, #000 80%);
+  color: #e4d4aa;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -17,6 +17,8 @@ body {
 h3, h4 {
   font-weight: 600;
   margin-bottom: .5em;
+  color: #d4af37;
+  text-shadow: 0 0 5px #000;
 }
 
 button, .btn {
@@ -180,34 +182,31 @@ header .controls {
 }
 
 .choice {
-  background: #222;
-  border: 1px solid #555;
-  padding: .5em;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background .2s, transform .2s;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
+    background: linear-gradient(#222, #111);
+    border: 1px solid #d4af37;
+    padding: .5em;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background .2s, transform .2s, box-shadow .2s;
+    display: flex;
+    align-items: center;
+    gap: .5em;
+  }
 
-.choice:hover {
-  background: #333;
-  transform: translateY(-2px);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
-}
+  .choice::before {
+    content: "\2620";
+    color: #d4af37;
+  }
 
-.choice .c-title {
-  font-weight: 500;
-}
+  .choice:hover {
+    background: linear-gradient(#333, #111);
+    transform: translateY(-2px);
+    box-shadow: 0 0 8px rgba(212,175,55,0.6);
+  }
 
-.choice .c-tag {
-  background: #333;
-  padding: .1em .4em;
-  border-radius: 3px;
-  font-size: .8em;
-  color: #ccc;
-}
+  .choice .c-title {
+    font-weight: 500;
+  }
 
 .footer-controls {
   margin-top: auto;
@@ -290,4 +289,23 @@ header .controls {
   background: url('warhammer-bg.jpg') center/cover no-repeat;
   opacity: 0.05;
   z-index: -1;
+}
+
+.hidden {
+  display: none;
+}
+
+.wow {
+  animation: wowFade .6s ease-out;
+}
+
+@keyframes wowFade {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }


### PR DESCRIPTION
## Summary
- Restyle layout for a gold-on-black Warhammer 40K look
- Hide favour/defavour tags and show skull choices
- Animate fluff then bonuses when resolving a choice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68986d2dcbc08332bdb472aa957135f1