### PR TITLE
Add start screen and phased narration flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -575,6 +575,9 @@ const restartBtn    = document.getElementById("restartBtn");
 const logEl         = document.getElementById("log");
 const badgeTourEl   = document.getElementById("badgeTour");
 const badgePhaseEl  = document.getElementById("badgePhase");
+const startScreen   = document.getElementById("startScreen");
+const startBtn      = document.getElementById("startBtn");
+const gameEl        = document.getElementById("game");
 
 // --- Utils ---
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
@@ -589,17 +592,37 @@ function init() {
   phaseIndex = 0;
   logEl.innerHTML = "";
   lastTagEl.textContent = "—";
+  nextBtn.textContent = "En attente de la prochaine étape";
+  nextBtn.style.display = "none";
+  nextBtn.disabled = true;
   updateHUD();
   afficherPhase();
 }
-init();
+
+startBtn.addEventListener("click", () => {
+  startScreen.style.display = "none";
+  gameEl.style.display = "";
+  init();
+});
 
 // --- Affichage d’une phase ---
+function typeNarration(text, cb) {
+  const words = text.split(" ");
+  narrationEl.textContent = "";
+  let i = 0;
+  const it = setInterval(() => {
+    narrationEl.textContent += (i > 0 ? " " : "") + words[i++];
+    if (i >= words.length) {
+      clearInterval(it);
+      if (cb) cb();
+    }
+  }, 300);
+}
+
 function afficherPhase() {
   const p = phases[phaseIndex];
   if (!p) return finDePartie();
 
-  narrationEl.textContent = p.narration;
   phaseTitleEl.textContent = p.phase;
   badgeTourEl.textContent = `Tour ${p.tour}`;
   badgePhaseEl.textContent = p.phase;
@@ -614,8 +637,15 @@ function afficherPhase() {
     btn.addEventListener("click", () => choisir(c));
     choicesEl.appendChild(btn);
   });
+  choicesEl.style.display = "none";
+  choicesEl.style.pointerEvents = "auto";
 
+  nextBtn.style.display = "none";
   nextBtn.disabled = true;
+
+  typeNarration(p.narration, () => {
+    choicesEl.style.display = "flex";
+  });
 }
 
 // --- Application d’un choix ---
@@ -643,6 +673,7 @@ function choisir(choix) {
   setTimeout(() => document.getElementById("bonus").classList.remove("hidden"), 4000);
 
   nextBtn.disabled = false;
+  choicesEl.style.pointerEvents = "none";
 }
 
 // --- HUD ---
@@ -657,12 +688,19 @@ function updateHUD() {
 function showModal(state) {
   modal.classList.toggle("show", !!state);
 }
-modalOk.addEventListener("click", () => showModal(false));
+modalOk.addEventListener("click", () => {
+  showModal(false);
+  nextBtn.style.display = "";
+});
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Enter" && modal.classList.contains("show")) showModal(false);
+  if (e.key === "Enter" && modal.classList.contains("show")) {
+    showModal(false);
+    nextBtn.style.display = "";
+  }
 });
 
 nextBtn.addEventListener("click", () => {
+  nextBtn.style.display = "none";
   if (phaseIndex < phases.length - 1) {
     phaseIndex++;
     afficherPhase();

--- a/index.html
+++ b/index.html
@@ -7,75 +7,80 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-
-<header>
-  <div class="brand">⚔️ <b>Le Promontoire</b> — Bataille narrative 40k</div>
-  <div class="controls">
-    <label class="toggle"><input id="sfxToggle" type="checkbox" checked/> Effets sonores</label>
-    <button class="btn secondary" id="restartBtn" title="Recommencer">Recommencer</button>
-    <button class="btn" id="nextBtn" title="Phase suivante" disabled>Phase suivante ▷</button>
+  <div id="startScreen" class="start-screen">
+    <button class="btn" id="startBtn">Commencer la Bataille du Promontoire</button>
   </div>
-</header>
 
-<div class="wrap">
-  <section class="stage">
-    <div class="stage-header">
-      <span class="badge"><span class="dot"></span><span id="badgeTour">Tour 1</span></span>
-      <span class="meta" id="badgePhase">Phase de Commandement</span>
-      <span class="meta">Ordre des choix mélangé à chaque phase.</span>
-    </div>
+  <div id="game" style="display:none;">
+    <header>
+      <div class="brand">⚔️ <b>Le Promontoire</b> — Bataille narrative 40k</div>
+      <div class="controls">
+        <label class="toggle"><input id="sfxToggle" type="checkbox" checked/> Effets sonores</label>
+        <button class="btn secondary" id="restartBtn" title="Recommencer">Recommencer</button>
+        <button class="btn" id="nextBtn" title="En attente de la prochaine étape" disabled>En attente de la prochaine étape</button>
+      </div>
+    </header>
 
-    <div class="narration">
-      <div class="scan"></div>
-      <div class="narr-text" id="narration"></div>
-    </div>
-    <div class="phase-title" id="phaseTitle"></div>
-    <div class="choices" id="choices"></div>
-
-    <div class="footer-controls">
-      <button class="btn ghost" id="skipBtn" title="Afficher un autre ordre de choix (sans changer la phase)">Remélanger</button>
-    </div>
-  </section>
-
-  <aside class="hud">
-    <div class="panel">
-      <h3>État de la bataille</h3>
-      <div class="stats">
-        <div class="meter">
-          <div class="statline"><span>Menace</span><span><b id="menaceVal">0</b></span></div>
-          <div class="bar"><div id="menaceFill" class="fill" style="width:12%"></div></div>
+    <div class="wrap">
+      <section class="stage">
+        <div class="stage-header">
+          <span class="badge"><span class="dot"></span><span id="badgeTour">Tour 1</span></span>
+          <span class="meta" id="badgePhase">Phase de Commandement</span>
+          <span class="meta">Ordre des choix mélangé à chaque phase.</span>
         </div>
-        <div class="meter">
-          <div class="statline"><span>Arrivées Tyranides (indicatif)</span><span><b id="tyrVal">0</b></span></div>
-          <div class="bar"><div id="tyrFill" class="fill" style="width:8%"></div></div>
+
+        <div class="narration">
+          <div class="scan"></div>
+          <div class="narr-text" id="narration"></div>
         </div>
-        <div class="statline"><span>Phase</span><span id="hudPhase">1 / 15</span></div>
-        <div class="statline"><span>Dernière résolution</span><span id="lastTag" class="tag">—</span></div>
+        <div class="phase-title" id="phaseTitle"></div>
+        <div class="choices" id="choices"></div>
+
+        <div class="footer-controls">
+          <button class="btn ghost" id="skipBtn" title="Afficher un autre ordre de choix (sans changer la phase)">Remélanger</button>
+        </div>
+      </section>
+
+      <aside class="hud">
+        <div class="panel">
+          <h3>État de la bataille</h3>
+          <div class="stats">
+            <div class="meter">
+              <div class="statline"><span>Menace</span><span><b id="menaceVal">0</b></span></div>
+              <div class="bar"><div id="menaceFill" class="fill" style="width:12%"></div></div>
+            </div>
+            <div class="meter">
+              <div class="statline"><span>Arrivées Tyranides (indicatif)</span><span><b id="tyrVal">0</b></span></div>
+              <div class="bar"><div id="tyrFill" class="fill" style="width:8%"></div></div>
+            </div>
+            <div class="statline"><span>Phase</span><span id="hudPhase">1 / 15</span></div>
+            <div class="statline"><span>Dernière résolution</span><span id="lastTag" class="tag">—</span></div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Journal</h3>
+          <div class="log" id="log"></div>
+        </div>
+      </aside>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal-backdrop" id="modal">
+      <div class="modal">
+        <h4 id="modalTitle">Résolution</h4>
+        <div class="fx" id="modalText"></div>
+        <div class="meta" id="modalMeta"></div>
+        <div class="row">
+          <span class="kbd">Entrée</span>
+          <button class="btn" id="modalOk">OK</button>
+        </div>
       </div>
     </div>
 
-    <div class="panel">
-      <h3>Journal</h3>
-      <div class="log" id="log"></div>
-    </div>
-  </aside>
-</div>
-
-<!-- Modal -->
-<div class="modal-backdrop" id="modal">
-  <div class="modal">
-    <h4 id="modalTitle">Résolution</h4>
-    <div class="fx" id="modalText"></div>
-    <div class="meta" id="modalMeta"></div>
-    <div class="row">
-      <span class="kbd">Entrée</span>
-      <button class="btn" id="modalOk">OK</button>
-    </div>
+    <div class="deco"></div>
   </div>
-</div>
 
-<div class="deco"></div>
-
-<script src="app.js" defer></script>
+  <script src="app.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,13 @@ body {
   flex-direction: column;
 }
 
+.start-screen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 h3, h4 {
   font-weight: 600;
   margin-bottom: .5em;


### PR DESCRIPTION
## Summary
- Add start screen with "Commencer la Bataille du Promontoire" button to begin the narrative
- Display phase narration word by word before showing choices
- Introduce "En attente de la prochaine étape" button to advance phases after resolving choices

## Testing
- `node --check app.js`
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6898717d09008332be215aad4e482b12