### PR TITLE
Ajout d'une apparition en fondu des choix

### DIFF
--- a/app.js
+++ b/app.js
@@ -628,7 +628,7 @@ function afficherPhase() {
   choicesEl.innerHTML = "";
   choixMelanges.forEach((c) => {
     const btn = document.createElement("div");
-    btn.className = "choice";
+    btn.className = "choice hidden";
     btn.innerHTML = `<div class="c-title">${c.texte}</div>`;
     btn.addEventListener("click", () => choisir(c));
     choicesEl.appendChild(btn);
@@ -641,6 +641,12 @@ function afficherPhase() {
 
   typeNarration(p.narration, () => {
     choicesEl.style.display = "flex";
+    Array.from(choicesEl.children).forEach((child, idx) => {
+      setTimeout(() => {
+        child.classList.remove("hidden");
+        requestAnimationFrame(() => child.classList.add("visible"));
+      }, idx * 1000);
+    });
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -194,10 +194,19 @@ header .controls {
     padding: .5em;
     border-radius: 4px;
     cursor: pointer;
-    transition: background .2s, transform .2s, box-shadow .2s;
     display: flex;
     align-items: center;
     gap: .5em;
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+    transition: background .2s, transform .2s, box-shadow .2s, opacity .5s;
+  }
+
+  .choice.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
   }
 
   .choice::before {


### PR DESCRIPTION
## Résumé
- Anime les options de phase en fondu
- Affiche les choix un à un toutes les secondes

## Tests
- `npm test` *(échoue : Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689874cfbcf48332a4f32b6881ababda