### PR TITLE
Fix(CSS): Correct color inheritance to improve contrast

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -36,7 +36,17 @@ h3, h4 {
   border: 1px solid var(--color-parchment-dark);
   box-shadow: 0 0 15px rgba(0,0,0,0.7);
   border-radius: 0;
-  color: var(--color-text);
+  /* color: var(--color-text); */ /* This was causing inheritance issues */
+}
+
+/* Apply text color directly to elements on parchment background */
+.panel .statline,
+.modal .fx,
+.narration,
+.phase-title,
+.choice,
+.log {
+    color: var(--color-text);
 }
 
 header {


### PR DESCRIPTION
The previous CSS rules in `theme.css` applied a black text color to several main container elements. This caused an issue where descendant elements with dark backgrounds (defined in `styles.css`, e.g., the `.kbd` element) would inherit this black text color, resulting in unreadable black-on-black text.

This commit refactors the CSS to resolve the issue. The broad, inherited text color rule has been removed from the container elements. Instead, the black text color is now applied directly and more specifically to child elements that are known to have light-colored backgrounds. This ensures that elements with dark backgrounds retain a light, readable text color.