### PR TITLE
Fix: Set initial gauge state to 50% and handle negative values

### DIFF
--- a/app.js
+++ b/app.js
@@ -583,7 +583,9 @@ const gameEl        = document.getElementById("game");
 // --- Utils ---
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
 function percentFrom(val, scale = 25) {
-  return clamp(Math.round((clamp(val, 0, scale) / scale) * 100), 0, 100);
+  const normalizedVal = clamp(val, -scale, scale);
+  const percentage = ((normalizedVal + scale) / (2 * scale)) * 100;
+  return clamp(Math.round(percentage), 0, 100);
 }
 
 // --- Initialisation ---


### PR DESCRIPTION
The gauges for Menace and Tyranid Arrivals now start at a 50% fill for better visual immersion, as requested.

The `percentFrom` utility function was updated to map a bipolar range (`-scale` to `+scale`) to the `0%` to `100%` width. This ensures a starting value of `0` correctly corresponds to a `50%` fill.

This change also fixes a bug where negative values for menace or tyranid arrivals were not correctly reflected in the gauge, as they were previously clamped to 0.