### PR TITLE
Feat: Adjust gauge visuals and hide numeric values

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -352,3 +352,8 @@ header .controls {
     transform: scale(1);
   }
 }
+
+/* Hide numeric values for meters */
+.meter .statline span:last-child {
+  display: none;
+}


### PR DESCRIPTION
- The gauges for Menace and Tyranid Arrivals now start at a 50% fill for better visual immersion.
- The `percentFrom` utility function was updated to map a bipolar range (`-scale` to `+scale`) to the `0%` to `100%` width. This also fixes a bug where negative values were not correctly reflected in the gauge.
- The numeric values for the gauges have been hidden via a new CSS rule to create a cleaner, more visual-focused interface.