### PR TITLE
Remove 'Remélanger' button

### DIFF
--- a/app.js
+++ b/app.js
@@ -571,7 +571,6 @@ const modalText     = document.getElementById("modalText");
 const modalMeta     = document.getElementById("modalMeta");
 const modalOk       = document.getElementById("modalOk");
 const nextBtn       = document.getElementById("nextBtn");
-const skipBtn       = document.getElementById("skipBtn");
 const restartBtn    = document.getElementById("restartBtn");
 const logEl         = document.getElementById("log");
 const badgeRoundEl  = document.getElementById("badgeRound");
@@ -731,10 +730,6 @@ nextBtn.addEventListener("click", () => {
   } else {
     finDePartie();
   }
-});
-
-skipBtn.addEventListener("click", () => {
-  afficherPhase();
 });
 
 restartBtn.addEventListener("click", init);

--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
         <div class="choices" id="choices"></div>
 
         <div class="footer-controls">
-          <button class="btn ghost" id="skipBtn" title="Afficher un autre ordre de choix (sans changer la phase)">Remélanger</button>
         </div>
       </section>
 


### PR DESCRIPTION
This commit removes the 'Remélanger' (Shuffle) button from the user interface.

The button element with id "skipBtn" was removed from `index.html`, and the corresponding JavaScript variable and event listener were removed from `app.js`.